### PR TITLE
Updating terraform, tf providers and github actions.

### DIFF
--- a/.github/workflows/terraform-workflow.yml
+++ b/.github/workflows/terraform-workflow.yml
@@ -29,7 +29,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: true
-          terraform_version: 1.9.3
+          terraform_version: 1.9.5
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: terraform-linters/setup-tflint@v4
       name: Setup TFLint
       with:
-        tflint_version: v0.51.1
+        tflint_version: v0.53.0
 
     - name: Show version
       run: tflint --version

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,31 +2,31 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.60.0"
-  constraints = ">= 4.0.0, >= 5.30.0, 5.60.0"
+  version     = "5.65.0"
+  constraints = ">= 4.0.0, >= 5.46.0, >= 5.60.0"
   hashes = [
-    "h1:msnFtzhM9fQgi5ePG7Skt5DvnqOiWqMSxCNBred/hso=",
-    "zh:08f49c9eb865e136a55dda3eb2b790f6d55cdac49f6638391dbea4b865cf307b",
-    "zh:090dd8b40ebf0f8e9ea05b9a142add9caeb7988d3d96c5c112e8c67c0edf566f",
-    "zh:30f336af1b4f0824fce2cc6e81af0986b325b135436c9d892d081e435aeed67e",
-    "zh:338195ca3b41249874110253412d8913f770c22294af05799ea1e343050906f5",
-    "zh:3a8a45b17750b01192a0fbeeed0d05c2c04840344d78d5e3233b3ecbeec17a1c",
-    "zh:486efe72d39f0736d9b7e00e5b889288264458a57aa0cff2d75688d6db372ee5",
-    "zh:5fdccc448a085fea8ecfae43ae326840abfcdf1a0aa8b8c79dd466392aa5cc3a",
-    "zh:9521639755cd07ec7efde86a534770e436e16a93692d070a00f6419c1038d59c",
+    "h1:LTqvpg2APqTRPmQIkOAFwn7Q8rXTXazDXIBaYSfLIm4=",
+    "zh:036f8557c8c9b58656e1ec08ed5702e44bd338fda17dc4b2add40b234102e29a",
+    "zh:0ba0708ece98735540070899a916b7a90c5c887be31ffd693ee1359e40245978",
+    "zh:12d82a82ae0e3bc580f2be961078e89d129e12df7dd82a6ec610a2b945bba1a4",
+    "zh:1ed0ee17df8807aef64976e2a4276d2a3e1d54efeae2a86f596d12eccb94dc83",
+    "zh:36b7c61a83d24f612156b4648027ba8bd5727f0ed57183cbad0e6c93b7503aa2",
+    "zh:496d06a089b1bc8d60995e8dddfe1d87c605a208f377a60b17987e89381dafda",
+    "zh:4e9aba435994589befe4279927c71a461a52e6cd96b8f0437295c18c50f6baff",
+    "zh:71134031288a312db1804d4798b10f106a843c36aafd7b8fe8f4859156d7df93",
+    "zh:748d0dbdfbe8df4b516a09b23b3981c19cef9a255c1ca0187e84ab424e6bd845",
+    "zh:783541ff77f4e7c74c817e0e2989ebdb45dd6e2c9853a8cccbcf5f1976736a76",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:c2fb9240a069da9f51e7379e76c3dfaad15a97430c2e32708a7d18345434e310",
-    "zh:daba836b89537dfa72bb8c77e88850c20fda2a3d0f5b3803cd3d6da0ce283e3e",
-    "zh:db7e0755ed120ed8311f6663f49aa7157da5072b906727db3a6c47d64e0b82c6",
-    "zh:ea5e3fca5197639c4ad1415ca96de2924a351ecd1a885dd9184843d5eec18dbb",
-    "zh:f3f322951d311e45a47361f24790a90a0b8ba6d3829a00c4066a361960d2ecef",
-    "zh:f48b44f4887d4b51a1406057f15f1e2161cb02b271b2659349958904c678e91c",
+    "zh:af3f080975d5ed79917b8238cc0ae3150da688bc89e12dcc3ee85134b29857d0",
+    "zh:ec542372c3ffbfc3df6966f77357f8af7319d4bd956ff8e9fde0bbd124352e34",
+    "zh:f3dc7b2b5b55173207c2fd35ed6bb8cc66b06af777e221060ca2f0c0afdecbb5",
+    "zh:f9631ecc21d6e5cf82ef6ef8d14c39e1dfb2a52cc8f0abb684311885ffdb79a1",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/dns" {
   version     = "3.4.1"
-  constraints = "3.4.1"
+  constraints = ">= 3.4.1"
   hashes = [
     "h1:6VWKyyb75bXOvm+jFNyOfu/cj0SdcDru7seMblWRBfc=",
     "zh:00fc9ba46d66a35c0f4cb66d19b402280f5d074a5652b6a378aac9b11b93d069",
@@ -46,7 +46,7 @@ provider "registry.terraform.io/hashicorp/dns" {
 
 provider "registry.terraform.io/hashicorp/external" {
   version     = "2.3.3"
-  constraints = "2.3.3"
+  constraints = ">= 2.3.3"
   hashes = [
     "h1:H+3QlVPs/7CDa3I4KU/a23wYeGeJxeBlgvR7bfK1t1w=",
     "zh:03d81462f9578ec91ce8e26f887e34151eda0e100f57e9772dbea86363588239",
@@ -66,7 +66,7 @@ provider "registry.terraform.io/hashicorp/external" {
 
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.2"
-  constraints = "3.2.2"
+  constraints = ">= 3.2.2"
   hashes = [
     "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
     "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
@@ -86,7 +86,7 @@ provider "registry.terraform.io/hashicorp/null" {
 
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.2"
-  constraints = "3.6.2"
+  constraints = ">= 3.6.2"
   hashes = [
     "h1:wmG0QFjQ2OfyPy6BB7mQ57WtoZZGGV07uAPQeDmIrAE=",
     "zh:0ef01a4f81147b32c1bea3429974d4d104bbc4be2ba3cfa667031a8183ef88ec",
@@ -106,7 +106,7 @@ provider "registry.terraform.io/hashicorp/random" {
 
 provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.0.5"
-  constraints = "4.0.5"
+  constraints = ">= 4.0.5"
   hashes = [
     "h1:e4LBdJoZJNOQXPWgOAG0UuPBVhCStu98PieNlqJTmeU=",
     "zh:01cfb11cb74654c003f6d4e32bbef8f5969ee2856394a96d127da4949c65153e",

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ No inputs.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.9.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.60.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.65.0 |
 | <a name="requirement_dns"></a> [dns](#requirement\_dns) | 3.4.1 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | 2.3.3 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | 3.2.2 |
@@ -99,8 +99,8 @@ No inputs.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.60.0 |
-| <a name="provider_aws.use1"></a> [aws.use1](#provider\_aws.use1) | 5.60.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
+| <a name="provider_aws.use1"></a> [aws.use1](#provider\_aws.use1) | 5.65.0 |
 | <a name="provider_dns"></a> [dns](#provider\_dns) | 3.4.1 |
 
 ## Modules
@@ -120,30 +120,30 @@ No inputs.
 
 | Name | Type |
 |------|------|
-| [aws_db_subnet_group.private](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/db_subnet_group) | resource |
-| [aws_db_subnet_group.public](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/db_subnet_group) | resource |
-| [aws_dynamodb_table.tfstate_lock](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/dynamodb_table) | resource |
-| [aws_ecr_lifecycle_policy.this](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/ecr_lifecycle_policy) | resource |
-| [aws_ecr_repository.this](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/ecr_repository) | resource |
-| [aws_iam_service_linked_role.spot](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/iam_service_linked_role) | resource |
-| [aws_kms_alias.capnduck_com](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/kms_alias) | resource |
-| [aws_kms_alias.tfstate](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/kms_alias) | resource |
-| [aws_kms_key.capnduck_com](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/kms_key) | resource |
-| [aws_kms_key.tfstate](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/kms_key) | resource |
-| [aws_route53_hosted_zone_dnssec.capnduck_com](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/route53_hosted_zone_dnssec) | resource |
-| [aws_route53_key_signing_key.capnduck_com](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/route53_key_signing_key) | resource |
-| [aws_route53_zone.capnduck_com](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/route53_zone) | resource |
-| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/route53_zone) | resource |
-| [aws_s3_bucket.tfstate](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_acl.tfstate](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/s3_bucket_acl) | resource |
-| [aws_s3_bucket_public_access_block.tfstate](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_server_side_encryption_configuration.tfstate](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
-| [aws_s3_bucket_versioning.tfstate](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/resources/s3_bucket_versioning) | resource |
-| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/data-sources/caller_identity) | data source |
-| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/data-sources/route53_zone) | data source |
-| [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/data-sources/subnets) | data source |
-| [aws_subnets.public](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/data-sources/subnets) | data source |
-| [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/5.60.0/docs/data-sources/vpc) | data source |
+| [aws_db_subnet_group.private](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/db_subnet_group) | resource |
+| [aws_db_subnet_group.public](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/db_subnet_group) | resource |
+| [aws_dynamodb_table.tfstate_lock](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/dynamodb_table) | resource |
+| [aws_ecr_lifecycle_policy.this](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/ecr_lifecycle_policy) | resource |
+| [aws_ecr_repository.this](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/ecr_repository) | resource |
+| [aws_iam_service_linked_role.spot](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/iam_service_linked_role) | resource |
+| [aws_kms_alias.capnduck_com](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/kms_alias) | resource |
+| [aws_kms_alias.tfstate](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/kms_alias) | resource |
+| [aws_kms_key.capnduck_com](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/kms_key) | resource |
+| [aws_kms_key.tfstate](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/kms_key) | resource |
+| [aws_route53_hosted_zone_dnssec.capnduck_com](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/route53_hosted_zone_dnssec) | resource |
+| [aws_route53_key_signing_key.capnduck_com](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/route53_key_signing_key) | resource |
+| [aws_route53_zone.capnduck_com](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/route53_zone) | resource |
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/route53_zone) | resource |
+| [aws_s3_bucket.tfstate](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_acl.tfstate](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_public_access_block.tfstate](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.tfstate](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.tfstate](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/resources/s3_bucket_versioning) | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/data-sources/caller_identity) | data source |
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/data-sources/route53_zone) | data source |
+| [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/data-sources/subnets) | data source |
+| [aws_subnets.public](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/data-sources/subnets) | data source |
+| [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/5.65.0/docs/data-sources/vpc) | data source |
 | [dns_a_record_set.home](https://registry.terraform.io/providers/hashicorp/dns/3.4.1/docs/data-sources/a_record_set) | data source |
 
 ## Inputs

--- a/readme.md
+++ b/readme.md
@@ -87,7 +87,7 @@ No inputs.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.9.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.9.5 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.60.0 |
 | <a name="requirement_dns"></a> [dns](#requirement\_dns) | 3.4.1 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | 2.3.3 |

--- a/terraform.tf
+++ b/terraform.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.60.0"
+      version = "5.65.0"
     }
     dns = {
       source  = "hashicorp/dns"

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "= 1.9.3"
+  required_version = "= 1.9.5"
   backend "s3" {
     bucket         = "capnduck-terraform-tfstate"
     key            = "terraform.tfstate"


### PR DESCRIPTION
- [x] Update `terraform` to `1.9.5`
- [x] Update github actions to also use `1.9.5` of `terraform`.
- [x] Update `tflint` engine version to `0.53.0`.
- [ ] Update `checkov` engine version. Will not do as `v12` is still the latest.
- [ ] Update `terraform-docs` to latest version. Will not do as `v1` is still the latest.